### PR TITLE
refactor: remove custom split(), use strings.Split

### DIFF
--- a/cmd/top.go
+++ b/cmd/top.go
@@ -229,32 +229,12 @@ func countPhases(pods []types.AgentPod) (running, completed, failed int) {
 
 func splitLines(s string) []string {
 	var lines []string
-	for _, l := range split(s, '\n') {
+	for _, l := range strings.Split(s, "\n") {
 		if l != "" {
 			lines = append(lines, l)
 		}
 	}
 	return lines
-}
-
-func split(s string, sep byte) []string {
-	var result []string
-	for len(s) > 0 {
-		idx := -1
-		for i := 0; i < len(s); i++ {
-			if s[i] == sep {
-				idx = i
-				break
-			}
-		}
-		if idx == -1 {
-			result = append(result, s)
-			break
-		}
-		result = append(result, s[:idx])
-		s = s[idx+1:]
-	}
-	return result
 }
 
 func runTop(cmd *cobra.Command, args []string) error {

--- a/cmd/top_test.go
+++ b/cmd/top_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitLines(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"a\nb\nc", []string{"a", "b", "c"}},
+		{"a\n\nb", []string{"a", "b"}},
+		{"", nil},
+		{"single", []string{"single"}},
+		{"trailing\n", []string{"trailing"}},
+	}
+	for _, tt := range tests {
+		got := splitLines(tt.input)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("splitLines(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6

## Changes

- Deleted the hand-rolled `split()` function (`cmd/top.go:240-258`)
- Replaced the single call site in `splitLines()` with `strings.Split(s, "\n")`
- Added `cmd/top_test.go` with tests for `splitLines` (regression gate)

## Acceptance

- [x] `split()` function deleted
- [x] `splitLines` uses `strings.Split`
- [x] Builds (strings import already present)
- [x] Regression test added