### PR TITLE
fix: walk cwd for repo root instead of os.Executable with hardcoded fallback

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -29,16 +29,28 @@ func runCmd(desc, cmd string) error {
 	return c.Run()
 }
 
-func runDeploy(cmd *cobra.Command, args []string) error {
-	// find repo root (where go.mod lives)
-	ex, _ := os.Executable()
-	repoRoot := filepath.Dir(ex)
-	// fallback: check common locations
-	for _, candidate := range []string{repoRoot, "/mnt/c/code/k3sc", "."} {
-		if _, err := os.Stat(filepath.Join(candidate, "manifests")); err == nil {
-			repoRoot = candidate
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
 			break
 		}
+		dir = parent
+	}
+	return "", fmt.Errorf("repo root not found: no go.mod in cwd or any parent directory")
+}
+
+func runDeploy(cmd *cobra.Command, args []string) error {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return err
 	}
 
 	imageDir := filepath.Join(repoRoot, "image")

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1,14 +1,16 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestPVCPrefix(t *testing.T) {
 	cases := []struct {
-		name   string
-		isPVC  bool
+		name  string
+		isPVC bool
 	}{
 		{"pvc-claude-a.yaml", true},
 		{"pvc-claude-b.yaml", true},
@@ -22,5 +24,48 @@ func TestPVCPrefix(t *testing.T) {
 		if got != c.isPVC {
 			t.Errorf("HasPrefix(%q, \"pvc-\") = %v, want %v", c.name, got, c.isPVC)
 		}
+	}
+}
+
+func TestFindRepoRoot(t *testing.T) {
+	// create temp dir tree: root/sub/sub2
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	sub2 := filepath.Join(sub, "sub2")
+	if err := os.MkdirAll(sub2, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// place go.mod in root
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// change to sub2 and verify findRepoRoot walks up to root
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+	if err := os.Chdir(sub2); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != root {
+		t.Fatalf("expected %q, got %q", root, got)
+	}
+}
+
+func TestFindRepoRootFromRepoDir(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	got, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("findRepoRoot from repo root returned error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(got, "go.mod")); statErr != nil {
+		t.Fatalf("returned path %q has no go.mod", got)
 	}
 }


### PR DESCRIPTION
Fixes #7

## Problem

`cmd/deploy.go:33-41` used `os.Executable()` to find the repo root (returns binary path, not repo root) then fell back to a hardcoded `/mnt/c/code/claude-k3`. This breaks if the binary moves or the repo is cloned elsewhere.

## Fix

Replaced with `findRepoRoot()` that walks up from `os.Getwd()` looking for `go.mod`. Returns a clear error if no `go.mod` is found, rather than silently using a wrong path.

## Changes

- `cmd/deploy.go`: add `findRepoRoot()`, remove `os.Executable()` and hardcoded fallback
- `cmd/deploy_test.go`: regression tests verifying `findRepoRoot()` walks up from a subdirectory and finds `go.mod`

## Test plan

- [ ] `TestFindRepoRoot`: creates a tempdir tree with `go.mod` at root, changes to a subdir, verifies `findRepoRoot` returns the root
- [ ] `TestFindRepoRootNotFound`: verifies running from actual repo root succeeds without hardcoded paths