### PR TITLE
feat: add resource limits to agent pod job template

### DIFF
--- a/manifests/job-template.yaml
+++ b/manifests/job-template.yaml
@@ -27,6 +27,13 @@ spec:
         - name: claude-agent
           image: claude-agent:latest
           imagePullPolicy: Never
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
           env:
             - name: ISSUE_NUMBER
               value: "__ISSUE_NUMBER__"


### PR DESCRIPTION
Closes #9

## Changes

Added resource requests and limits to the `claude-agent` container in `manifests/job-template.yaml`:

```yaml
resources:
  requests:
    memory: "512Mi"
    cpu: "500m"
  limits:
    memory: "4Gi"
    cpu: "2"
```

Prevents a runaway cargo build from OOMing the node.

## Compliance

- k8s.md: n/a (no Def/Instance/Controller changes)
- authority.md: n/a (no data ownership changes)
- performance.md: n/a (manifest-only change, no hot paths)