### PR TITLE
perf: reuse k8s client instead of creating per-gather-cycle

### DIFF
--- a/cmd/top.go
+++ b/cmd/top.go
@@ -15,6 +15,7 @@ import (
 	"github.com/abix-/k3sc/internal/types"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
 
@@ -78,12 +79,8 @@ type dashboard struct {
 	dispatcherLog string
 }
 
-func gather() (*dashboard, error) {
+func gather(cs *kubernetes.Clientset) (*dashboard, error) {
 	ctx := context.Background()
-	cs, err := k8s.NewClient()
-	if err != nil {
-		return nil, err
-	}
 
 	var (
 		nodeName, nodeVersion string
@@ -222,8 +219,13 @@ func printDashboard(d *dashboard) {
 }
 
 func runTop(cmd *cobra.Command, args []string) error {
+	cs, err := k8s.NewClient()
+	if err != nil {
+		return err
+	}
+
 	if once {
-		d, err := gather()
+		d, err := gather(cs)
 		if err != nil {
 			return err
 		}
@@ -238,7 +240,7 @@ func runTop(cmd *cobra.Command, args []string) error {
 
 	// TUI mode
 	gatherFn := func() (*tui.Data, error) {
-		d, err := gather()
+		d, err := gather(cs)
 		if err != nil {
 			return nil, err
 		}
@@ -254,10 +256,6 @@ func runTop(cmd *cobra.Command, args []string) error {
 
 	k8sGatherFn := func(current *tui.Data) (*tui.Data, error) {
 		ctx := context.Background()
-		cs, err := k8s.NewClient()
-		if err != nil {
-			return nil, err
-		}
 
 		var (
 			pods    []types.AgentPod
@@ -332,6 +330,6 @@ func runTop(cmd *cobra.Command, args []string) error {
 
 	m := tui.NewModel(gatherFn, k8sGatherFn, dispatchFn, maxSlots, setMaxSlots, logBuf.Lines)
 	p := tea.NewProgram(m, tea.WithAltScreen())
-	_, err := p.Run()
+	_, err = p.Run()
 	return err
 }

--- a/cmd/top_test.go
+++ b/cmd/top_test.go
@@ -1,0 +1,10 @@
+package cmd
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+// Compile-time assertion: gather must accept *kubernetes.Clientset.
+// If gather were reverted to call k8s.NewClient() internally (the bug),
+// it would no longer have this parameter and this file would not compile.
+var _ func(*kubernetes.Clientset) (*dashboard, error) = gather


### PR DESCRIPTION
## Summary
- Moves `k8s.NewClient()` from inside `gather()` and `k8sGatherFn` to a single call at `runTop` startup
- Client is passed into `gather(cs)` and captured by the `k8sGatherFn` closure
- Eliminates config loading and TLS handshake overhead on every 3s/30s refresh cycle

## Regression test
`cmd/top_test.go` contains a compile-time assertion:
```go
var _ func(*kubernetes.Clientset) (*dashboard, error) = gather
```
If anyone reverts `gather` to create the client internally (removing the parameter), this file will fail to compile.

## Changes
- `cmd/top.go`: `gather()` -> `gather(cs *kubernetes.Clientset)`, client created once in `runTop`
- `cmd/top_test.go`: compile-time regression guard on the function signature

Closes #8