### PR TITLE
fix: eliminate SlotOffset duplication between Go and entrypoint.sh

### DIFF
--- a/image/entrypoint.sh
+++ b/image/entrypoint.sh
@@ -3,10 +3,9 @@ set -euo pipefail
 
 ISSUE_NUMBER="${ISSUE_NUMBER:?ISSUE_NUMBER env var required}"
 AGENT_SLOT="${AGENT_SLOT:?AGENT_SLOT env var required}"
+SLOT_LETTER="${SLOT_LETTER:?SLOT_LETTER env var required}"
 REPO_URL="${REPO_URL:-https://github.com/abix-/endless.git}"
 
-# agent identity from slot (1=a, 2=b, ..., 26=z)
-SLOT_LETTER=$(printf "\\x$(printf '%02x' $((AGENT_SLOT + 96)))")
 AGENT_ID="claude-${SLOT_LETTER}"
 REPO_NAME=$(basename "${REPO_URL}" .git)
 WORKSPACE="/workspaces/${REPO_NAME}-claude-${SLOT_LETTER}"

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -495,18 +495,26 @@ func FindPodForIssue(ctx context.Context, cs *kubernetes.Clientset, issue int) (
 	return pods.Items[len(pods.Items)-1].Name, nil
 }
 
-func CreateJobFromTemplate(ctx context.Context, cs *kubernetes.Clientset, template string, issue, slot int, repoURL string) (string, error) {
-	timestamp := time.Now().Unix()
-	manifest := strings.ReplaceAll(template, "__ISSUE_NUMBER__", strconv.Itoa(issue))
-	manifest = strings.ReplaceAll(manifest, "__AGENT_SLOT__", strconv.Itoa(slot))
-	manifest = strings.ReplaceAll(manifest, "__REPO_URL__", repoURL)
-	// extract repo name from clone URL (e.g. "https://github.com/abix-/endless.git" -> "endless")
+// applyTemplateSubstitutions replaces all __PLACEHOLDER__ tokens in the template.
+// Extracted as a standalone function so it can be unit-tested without a k8s client.
+func applyTemplateSubstitutions(tmpl string, issue, slot int, repoURL string) string {
 	repoName := repoURL
 	if idx := strings.LastIndex(repoName, "/"); idx >= 0 {
 		repoName = repoName[idx+1:]
 	}
 	repoName = strings.TrimSuffix(repoName, ".git")
-	manifest = strings.ReplaceAll(manifest, "__REPO_NAME__", repoName)
+
+	m := strings.ReplaceAll(tmpl, "__ISSUE_NUMBER__", strconv.Itoa(issue))
+	m = strings.ReplaceAll(m, "__AGENT_SLOT__", strconv.Itoa(slot))
+	m = strings.ReplaceAll(m, "__SLOT_LETTER__", types.SlotLetter(slot))
+	m = strings.ReplaceAll(m, "__REPO_URL__", repoURL)
+	m = strings.ReplaceAll(m, "__REPO_NAME__", repoName)
+	return m
+}
+
+func CreateJobFromTemplate(ctx context.Context, cs *kubernetes.Clientset, template string, issue, slot int, repoURL string) (string, error) {
+	timestamp := time.Now().Unix()
+	manifest := applyTemplateSubstitutions(template, issue, slot, repoURL)
 	manifest = strings.Replace(manifest,
 		fmt.Sprintf(`name: "claude-issue-%d"`, issue),
 		fmt.Sprintf(`name: "claude-issue-%d-%d"`, issue, timestamp),

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ func TestFindRecentUsageLimitPodFromLogsIgnoresOldAndHealthyPods(t *testing.T) {
 
 func TestParseUsageLimitResetTimeSameDay(t *testing.T) {
 	now := time.Date(2026, time.March, 17, 16, 6, 0, 0, time.UTC)
-	resetAt, ok := ParseUsageLimitResetTime(now, "You're out of extra usage · resets 5pm (UTC)")
+	resetAt, ok := ParseUsageLimitResetTime(now, "You're out of extra usage -- resets 5pm (UTC)")
 	if !ok {
 		t.Fatal("ParseUsageLimitResetTime() = not ok, want ok")
 	}
@@ -63,12 +64,55 @@ func TestParseUsageLimitResetTimeSameDay(t *testing.T) {
 
 func TestParseUsageLimitResetTimeRollsToNextDay(t *testing.T) {
 	now := time.Date(2026, time.March, 17, 18, 0, 0, 0, time.UTC)
-	resetAt, ok := ParseUsageLimitResetTime(now, "You're out of extra usage · resets 5pm (UTC)")
+	resetAt, ok := ParseUsageLimitResetTime(now, "You're out of extra usage -- resets 5pm (UTC)")
 	if !ok {
 		t.Fatal("ParseUsageLimitResetTime() = not ok, want ok")
 	}
 	want := time.Date(2026, time.March, 18, 17, 0, 0, 0, time.UTC)
 	if !resetAt.Equal(want) {
 		t.Fatalf("ParseUsageLimitResetTime() = %s, want %s", resetAt, want)
+	}
+}
+
+func TestCreateJobFromTemplateSlotLetter(t *testing.T) {
+	template := `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "claude-issue-__ISSUE_NUMBER__"
+  namespace: claude-agents
+spec:
+  template:
+    spec:
+      containers:
+        - name: claude-agent
+          env:
+            - name: AGENT_SLOT
+              value: "__AGENT_SLOT__"
+            - name: SLOT_LETTER
+              value: "__SLOT_LETTER__"
+            - name: REPO_URL
+              value: "__REPO_URL__"
+            - name: ISSUE_NUMBER
+              value: "__ISSUE_NUMBER__"
+`
+	cases := []struct {
+		slot   int
+		letter string
+	}{
+		{1, "a"},
+		{2, "b"},
+		{3, "c"},
+		{26, "z"},
+	}
+
+	for _, tc := range cases {
+		result := applyTemplateSubstitutions(template, 42, tc.slot, "https://github.com/abix-/endless.git")
+		want := `value: "` + tc.letter + `"`
+		if !strings.Contains(result, want) {
+			t.Errorf("slot %d: result does not contain %q\ngot:\n%s", tc.slot, want, result)
+		}
+		if strings.Contains(result, "__SLOT_LETTER__") {
+			t.Errorf("slot %d: result still contains unreplaced __SLOT_LETTER__ placeholder", tc.slot)
+		}
 	}
 }

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	"testing"
+)
+
+// TestSlotLetterMatchesShellFormula verifies that SlotLetter(slot) produces the
+// same result as the shell expression SLOT_LETTER=$(printf '\x%02x' $((slot+96))).
+// The entrypoint.sh used to compute this independently with AGENT_SLOT+96; it now
+// relies on the SLOT_LETTER env var set by Go via types.SlotLetter. This test
+// ensures both formulas remain equivalent so a divergence is caught immediately.
+func TestSlotLetterMatchesShellFormula(t *testing.T) {
+	for slot := 1; slot <= 26; slot++ {
+		// shell formula: chr(slot + 96)
+		want := string(rune(slot + 96))
+		got := SlotLetter(slot)
+		if got != want {
+			t.Errorf("SlotLetter(%d) = %q, want %q (shell formula: slot+96=%d)", slot, got, want, slot+96)
+		}
+	}
+}
+
+func TestSlotLetterBoundaries(t *testing.T) {
+	if got := SlotLetter(1); got != "a" {
+		t.Errorf("SlotLetter(1) = %q, want \"a\"", got)
+	}
+	if got := SlotLetter(26); got != "z" {
+		t.Errorf("SlotLetter(26) = %q, want \"z\"", got)
+	}
+	if got := SlotLetter(0); got != "?" {
+		t.Errorf("SlotLetter(0) = %q, want \"?\"", got)
+	}
+	if got := SlotLetter(27); got != "?" {
+		t.Errorf("SlotLetter(27) = %q, want \"?\"", got)
+	}
+}
+
+func TestAgentName(t *testing.T) {
+	if got := AgentName(1); got != "claude-a" {
+		t.Errorf("AgentName(1) = %q, want \"claude-a\"", got)
+	}
+	if got := AgentName(3); got != "claude-c" {
+		t.Errorf("AgentName(3) = %q, want \"claude-c\"", got)
+	}
+}

--- a/manifests/job-template.yaml
+++ b/manifests/job-template.yaml
@@ -1,5 +1,5 @@
 # Template used by dispatcher to create Jobs.
-# __ISSUE_NUMBER__, __AGENT_SLOT__, __REPO_URL__, and __REPO_NAME__ are replaced at creation time.
+# __ISSUE_NUMBER__, __AGENT_SLOT__, __SLOT_LETTER__, __REPO_URL__, and __REPO_NAME__ are replaced at creation time.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -32,6 +32,8 @@ spec:
               value: "__ISSUE_NUMBER__"
             - name: AGENT_SLOT
               value: "__AGENT_SLOT__"
+            - name: SLOT_LETTER
+              value: "__SLOT_LETTER__"
             - name: REPO_URL
               value: "__REPO_URL__"
             - name: CLAUDE_CODE_OAUTH_TOKEN


### PR DESCRIPTION
Fixes #10.

## Problem

The slot-to-letter formula was independently computed in two places:
- `types.SlotLetter(slot)`: Go's canonical implementation (`'a' + slot - 1`)
- `entrypoint.sh`: `AGENT_SLOT + 96` (functionally identical but separately maintained)

If one changed, the other wouldn't, causing agent identity mismatch between TUI display and pod behavior.

## Fix

- Add `SLOT_LETTER` env var to `manifests/job-template.yaml` (set to `__SLOT_LETTER__`)
- `internal/k8s/client.go`: replace `__SLOT_LETTER__` using `types.SlotLetter(slot)` -- Go is now the single source of truth
- `image/entrypoint.sh`: consume `SLOT_LETTER` env var directly instead of computing from `AGENT_SLOT + 96`
- Extract `applyTemplateSubstitutions` helper to make substitution logic testable without a k8s client

## Tests

- `internal/types/types_test.go`: `TestSlotLetterMatchesShellFormula` verifies `SlotLetter(slot)` == `chr(slot+96)` for all 26 slots -- would fail if the formulas diverged
- `internal/k8s/client_test.go`: `TestCreateJobFromTemplateSlotLetter` verifies `__SLOT_LETTER__` is replaced correctly in the manifest