### PR TITLE
hardening: change PVC access mode from ReadWriteOnce to ReadWriteMany

### DIFF
--- a/manifests/pvc-cargo-home.yaml
+++ b/manifests/pvc-cargo-home.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: claude-agents
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   storageClassName: local-path
   resources:
     requests:

--- a/manifests/pvc-cargo-target.yaml
+++ b/manifests/pvc-cargo-target.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: claude-agents
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   storageClassName: local-path
   resources:
     requests:

--- a/manifests/pvc-workspaces.yaml
+++ b/manifests/pvc-workspaces.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: claude-agents
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   storageClassName: local-path
   resources:
     requests:


### PR DESCRIPTION
Fixes #11

## Summary
- Changed `accessModes` from `ReadWriteOnce` to `ReadWriteMany` in all three PVCs: `pvc-cargo-target.yaml`, `pvc-cargo-home.yaml`, `pvc-workspaces.yaml`

Multiple agent pods mount these PVCs concurrently. `ReadWriteOnce` is semantically incorrect even though local-path provisioner doesn't enforce it. `ReadWriteMany` documents the actual intent and will be correct on any real storage backend.

## Files Changed
- `manifests/pvc-cargo-target.yaml`
- `manifests/pvc-cargo-home.yaml`
- `manifests/pvc-workspaces.yaml`