### PR TITLE
feat: dispatcher owns claim -- eliminate agent race condition

### DIFF
--- a/cmd/dispatch.go
+++ b/cmd/dispatch.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/abix-/k3sc/internal/github"
 	"github.com/abix-/k3sc/internal/k8s"
+	"github.com/abix-/k3sc/internal/types"
 	"github.com/spf13/cobra"
 )
 
@@ -176,10 +177,18 @@ func runDispatchInner() (string, error) {
 			break
 		}
 
-		log = append(log, fmt.Sprintf("[dispatcher] creating job for %s/%s#%d in slot %d", issue.Repo.Owner, issue.Repo.Name, issue.Number, slot))
+		agentName := types.AgentName(slot)
+		log = append(log, fmt.Sprintf("[dispatcher] claiming %s#%d for %s (slot %d)", issue.Repo.Name, issue.Number, agentName, slot))
+
+		if err := github.ClaimIssue(ctx, issue.Repo, issue.Number, agentName); err != nil {
+			log = append(log, fmt.Sprintf("  CLAIM ERROR: %v", err))
+			continue
+		}
+		log = append(log, fmt.Sprintf("  claimed on github"))
+
 		name, err := k8s.CreateJobFromTemplate(ctx, cs, string(template), issue.Number, slot, issue.Repo.CloneURL())
 		if err != nil {
-			log = append(log, fmt.Sprintf("  ERROR: %v", err))
+			log = append(log, fmt.Sprintf("  JOB ERROR: %v", err))
 		} else {
 			log = append(log, fmt.Sprintf("  job.batch/%s created", name))
 		}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -148,6 +148,30 @@ func GetAllOpenIssues(ctx context.Context) ([]types.Issue, error) {
 	return result, nil
 }
 
+// ClaimIssue transitions an issue from ready/needs-review to claimed with an owner label.
+// It removes ready and needs-review labels, adds claimed + owner label, and posts a claim comment.
+func ClaimIssue(ctx context.Context, repo types.Repo, issueNumber int, agentName string) error {
+	client := newClient(ctx)
+
+	// remove ready and needs-review, add claimed
+	for _, label := range []string{"ready", "needs-review"} {
+		client.Issues.RemoveLabelForIssue(ctx, repo.Owner, repo.Name, issueNumber, label)
+	}
+	_, _, err := client.Issues.AddLabelsToIssue(ctx, repo.Owner, repo.Name, issueNumber, []string{"claimed", agentName})
+	if err != nil {
+		return fmt.Errorf("add labels: %w", err)
+	}
+
+	// post claim comment
+	body := fmt.Sprintf("## Claude\n- State: ready -> claimed\n- Owner: %s\n- Intent: dispatched by k3sc dispatcher", agentName)
+	_, _, err = client.Issues.CreateComment(ctx, repo.Owner, repo.Name, issueNumber, &gh.IssueComment{Body: &body})
+	if err != nil {
+		return fmt.Errorf("post comment: %w", err)
+	}
+
+	return nil
+}
+
 func GetWorkflowIssues(ctx context.Context) ([]types.Issue, error) {
 	return GetAllOpenIssues(ctx)
 }


### PR DESCRIPTION
## Summary

- Dispatcher now claims issues on GitHub (removes ready/needs-review, adds claimed + agent owner label, posts claim comment) before creating the k8s Job
- Added `github.ClaimIssue()` function for label transitions + comment
- Agents no longer race to claim -- dispatcher serializes all assignments
- Updated `/issue` skill to skip claiming when dispatched (issue already claimed)

Closes #26