### PR TITLE
feat: dispatcher posts pod result comments on issues

### DIFF
--- a/cmd/dispatch.go
+++ b/cmd/dispatch.go
@@ -125,6 +125,32 @@ func runDispatchInner() (string, error) {
 		}
 	}
 
+	// report results for pods that finished since last scan
+	unreported, err := k8s.FindUnreportedFinishedPods(ctx, cs)
+	if err != nil {
+		log = append(log, fmt.Sprintf("[dispatcher] unreported pods error: %v", err))
+	} else {
+		for _, pod := range unreported {
+			lines, lerr := k8s.GetPodLogLines(ctx, cs, pod.Name, 20)
+			if lerr != nil {
+				log = append(log, fmt.Sprintf("[dispatcher] log fetch error for %s: %v", pod.Name, lerr))
+			}
+			var dur time.Duration
+			if pod.Started != nil && pod.Finished != nil {
+				dur = pod.Finished.Sub(*pod.Started)
+			}
+			agentName := types.AgentName(pod.Slot)
+			if cerr := github.PostPodResultComment(ctx, pod.Repo, pod.Issue, agentName, pod.Phase, dur, lines); cerr != nil {
+				log = append(log, fmt.Sprintf("[dispatcher] comment error for %s: %v", pod.Name, cerr))
+			} else {
+				log = append(log, fmt.Sprintf("[dispatcher] posted result comment for %s#%d (%s)", pod.Repo.Name, pod.Issue, pod.Phase))
+				if aerr := k8s.MarkPodResultReported(ctx, cs, pod.Name); aerr != nil {
+					log = append(log, fmt.Sprintf("[dispatcher] annotate error for %s: %v", pod.Name, aerr))
+				}
+			}
+		}
+	}
+
 	eligible, err := github.GetEligibleIssues(ctx)
 	if err != nil {
 		log = append(log, fmt.Sprintf("[dispatcher] github error: %v", err))

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/abix-/k3sc/internal/types"
 	gh "github.com/google/go-github/v68/github"
@@ -231,6 +232,27 @@ func HasOpenPR(ctx context.Context, repo types.Repo, issueNumber int) (bool, err
 // PostComment posts a comment on a GitHub issue.
 func PostComment(ctx context.Context, repo types.Repo, issueNumber int, body string) error {
 	client := newClient(ctx)
+	_, _, err := client.Issues.CreateComment(ctx, repo.Owner, repo.Name, issueNumber, &gh.IssueComment{Body: &body})
+	return err
+}
+
+// PostPodResultComment posts a comment on a GitHub issue with the pod's result.
+func PostPodResultComment(ctx context.Context, repo types.Repo, issueNumber int, agentName string, phase types.PodPhase, duration time.Duration, logLines []string) error {
+	client := newClient(ctx)
+
+	status := "succeeded"
+	if phase == types.PhaseFailed {
+		status = "FAILED"
+	}
+
+	durStr := duration.Round(time.Second).String()
+
+	logSection := "(no logs)"
+	if len(logLines) > 0 {
+		logSection = "```\n" + strings.Join(logLines, "\n") + "\n```"
+	}
+
+	body := fmt.Sprintf("## Claude\n- Agent: %s\n- Result: %s\n- Duration: %s\n\n**Log tail:**\n%s", agentName, status, durStr, logSection)
 	_, _, err := client.Issues.CreateComment(ctx, repo.Owner, repo.Name, issueNumber, &gh.IssueComment{Body: &body})
 	return err
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -16,12 +16,14 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
+	PodResultReportedAnnotation        = "k3sc.abix.dev/result-reported"
 	DispatcherCronJobName              = "claude-dispatcher"
 	DispatcherDefaultSchedule          = "*/3 * * * *"
 	DispatcherHourlySchedule           = "0 * * * *"
@@ -299,6 +301,81 @@ func SetDispatcherBackoff(ctx context.Context, cs *kubernetes.Clientset, name st
 		return false, previous, err
 	}
 	return true, previous, nil
+}
+
+// FilterUnreportedFinishedPods returns pods that have finished (succeeded or failed)
+// with a non-zero issue number and are not in the reported set.
+func FilterUnreportedFinishedPods(pods []types.AgentPod, reported map[string]bool) []types.AgentPod {
+	var result []types.AgentPod
+	for _, pod := range pods {
+		if pod.Phase != types.PhaseSucceeded && pod.Phase != types.PhaseFailed {
+			continue
+		}
+		if pod.Issue == 0 {
+			continue
+		}
+		if reported[pod.Name] {
+			continue
+		}
+		result = append(result, pod)
+	}
+	return result
+}
+
+// FindUnreportedFinishedPods fetches agent pods from k8s and returns those that
+// finished but have not yet had their result posted to GitHub.
+func FindUnreportedFinishedPods(ctx context.Context, cs *kubernetes.Clientset) ([]types.AgentPod, error) {
+	rawPods, err := cs.CoreV1().Pods(types.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=claude-agent",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	reported := map[string]bool{}
+	for _, p := range rawPods.Items {
+		if p.Annotations[PodResultReportedAnnotation] == "true" {
+			reported[p.Name] = true
+		}
+	}
+
+	var pods []types.AgentPod
+	for _, p := range rawPods.Items {
+		issue, _ := strconv.Atoi(p.Labels["issue-number"])
+		slot, _ := strconv.Atoi(p.Labels["agent-slot"])
+		phase := types.PodPhase(p.Status.Phase)
+		repo := types.RepoByName(p.Labels["repo"])
+
+		var started, finished *time.Time
+		if p.Status.StartTime != nil {
+			t := p.Status.StartTime.Time
+			started = &t
+		}
+		if len(p.Status.ContainerStatuses) > 0 {
+			if term := p.Status.ContainerStatuses[0].State.Terminated; term != nil {
+				t := term.FinishedAt.Time
+				finished = &t
+			}
+		}
+		pods = append(pods, types.AgentPod{
+			Name:     p.Name,
+			Issue:    issue,
+			Slot:     slot,
+			Phase:    phase,
+			Started:  started,
+			Finished: finished,
+			Repo:     repo,
+		})
+	}
+
+	return FilterUnreportedFinishedPods(pods, reported), nil
+}
+
+// MarkPodResultReported annotates a pod to prevent double-posting its result.
+func MarkPodResultReported(ctx context.Context, cs *kubernetes.Clientset, podName string) error {
+	patch := []byte(`{"metadata":{"annotations":{"k3sc.abix.dev/result-reported":"true"}}}`)
+	_, err := cs.CoreV1().Pods(types.Namespace).Patch(ctx, podName, ktypes.MergePatchType, patch, metav1.PatchOptions{})
+	return err
 }
 
 func GetPodLogTail(ctx context.Context, cs *kubernetes.Clientset, podName string, lines int64) (string, error) {

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -61,6 +61,52 @@ func TestParseUsageLimitResetTimeSameDay(t *testing.T) {
 	}
 }
 
+func TestFilterUnreportedFinishedPodsSkipsReported(t *testing.T) {
+	finished := time.Now()
+	pods := []types.AgentPod{
+		{Name: "pod-a", Issue: 10, Phase: types.PhaseSucceeded, Finished: &finished},
+		{Name: "pod-b", Issue: 11, Phase: types.PhaseFailed, Finished: &finished},
+		{Name: "pod-c", Issue: 12, Phase: types.PhaseSucceeded, Finished: &finished},
+	}
+	reported := map[string]bool{"pod-a": true}
+
+	result := FilterUnreportedFinishedPods(pods, reported)
+	if len(result) != 2 {
+		t.Fatalf("FilterUnreportedFinishedPods() = %d pods, want 2", len(result))
+	}
+	for _, p := range result {
+		if p.Name == "pod-a" {
+			t.Fatal("FilterUnreportedFinishedPods() returned already-reported pod pod-a")
+		}
+	}
+}
+
+func TestFilterUnreportedFinishedPodsSkipsRunning(t *testing.T) {
+	finished := time.Now()
+	pods := []types.AgentPod{
+		{Name: "pod-run", Issue: 10, Phase: types.PhaseRunning},
+		{Name: "pod-done", Issue: 11, Phase: types.PhaseSucceeded, Finished: &finished},
+	}
+
+	result := FilterUnreportedFinishedPods(pods, map[string]bool{})
+	if len(result) != 1 || result[0].Name != "pod-done" {
+		t.Fatalf("FilterUnreportedFinishedPods() = %v, want [pod-done]", result)
+	}
+}
+
+func TestFilterUnreportedFinishedPodsSkipsZeroIssue(t *testing.T) {
+	finished := time.Now()
+	pods := []types.AgentPod{
+		{Name: "pod-no-issue", Issue: 0, Phase: types.PhaseSucceeded, Finished: &finished},
+		{Name: "pod-has-issue", Issue: 5, Phase: types.PhaseFailed, Finished: &finished},
+	}
+
+	result := FilterUnreportedFinishedPods(pods, map[string]bool{})
+	if len(result) != 1 || result[0].Name != "pod-has-issue" {
+		t.Fatalf("FilterUnreportedFinishedPods() = %v, want [pod-has-issue]", result)
+	}
+}
+
 func TestParseUsageLimitResetTimeRollsToNextDay(t *testing.T) {
 	now := time.Date(2026, time.March, 17, 18, 0, 0, 0, time.UTC)
 	resetAt, ok := ParseUsageLimitResetTime(now, "You're out of extra usage · resets 5pm (UTC)")


### PR DESCRIPTION
Closes #31

## What

On each dispatcher scan cycle, after the usage-limit check and before dispatching new jobs, detect finished pods that haven't been reported yet and post a GitHub comment on the linked issue.

## How

**k8s package:**
- `FilterUnreportedFinishedPods(pods, reported)` -- pure function: filters to finished (succeeded/failed) pods with non-zero issue number not in the reported set. Fully unit-tested.
- `FindUnreportedFinishedPods(ctx, cs)` -- fetches raw pods once, builds the reported map from `k3sc.abix.dev/result-reported` annotation, delegates to the pure filter.
- `MarkPodResultReported(ctx, cs, podName)` -- merge-patches the pod annotation to prevent double-posting.

**github package:**
- `PostPodResultComment(ctx, repo, issueNumber, agentName, phase, duration, logLines)` -- formats and posts the result comment.

**dispatcher:**
- Calls `FindUnreportedFinishedPods`, fetches 20-line log tail, posts comment, marks reported. Errors are logged but non-fatal (scan continues).

## Comment format

```
## Claude
- Agent: claude-a
- Result: FAILED
- Duration: 4m32s

**Log tail:**
```
<last 20 log lines>
```
```

## Tests

Three regression tests for `FilterUnreportedFinishedPods`:
- Skips pods already in the reported map
- Skips running/pending pods
- Skips pods with issue number 0 (non-agent pods)

> Note: Go toolchain is not available in this agent container. Build/vet/test acceptance criteria require verification in an environment with Go installed.