### PR TITLE
fix: bench-check unit conversion (criterion point_estimate is ns, not s)

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -126,7 +126,7 @@ func collectCriterionResults(criterionDir string) (map[string]float64, error) {
 		if err := json.Unmarshal(data, &est); err != nil {
 			return nil
 		}
-		results[key] = est.Mean.PointEstimate * 1e9 // seconds -> nanoseconds
+		results[key] = est.Mean.PointEstimate // nanoseconds (Criterion point_estimate is already ns)
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Problem

`k3sc bench-check` was multiplying Criterion's `point_estimate` by `1e9` treating it as seconds-to-nanoseconds conversion. But Criterion already stores `point_estimate` in nanoseconds. This caused a 1e9x inflation of all current run values, making every benchmark look like a catastrophic regression.

Example: `advance_waypoints_system/1000` baseline 5us -> reported current 3,463,901ms (instead of ~3.4us).

## Fix

Remove the `* 1e9` multiplier. Criterion `point_estimate` is already in nanoseconds.

## Impact

- All 36 existing benchmarks were reporting as 100% regressions (false positives)
- After fix, bench CI will correctly compare nanosecond values
- Unblocks PR abix-/endless#194 bench CI step